### PR TITLE
Updating ApmAudio to only show credit markup is audio_credit property…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apmg/amat",
   "authors": "[Geoff Hankerson ghankerson@mpr.org, Kim Thompson kthompson@mpr.org, Jason Phan jphan@mpr.org]",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "main": "dist/bundle.js",
   "license": "MIT",

--- a/src/atoms/ApmAudio/ApmAudio.js
+++ b/src/atoms/ApmAudio/ApmAudio.js
@@ -25,7 +25,9 @@ const ApmAudio = (props) => {
         ></amp-audio>
         <figcaption className="figure_caption">
           <div className="figure_caption_content">{title}</div>
-          <span className="figure_credit">by {audio_credit}</span>
+          {audio_credit && (
+            <span className="figure_credit">by {audio_credit}</span>
+          )}
         </figcaption>
       </figure>
     );


### PR DESCRIPTION
… is present. #44155