### PR TITLE
Fix duplicate React key when a node has marks

### DIFF
--- a/src/components/Body/Body.test.js
+++ b/src/components/Body/Body.test.js
@@ -119,6 +119,48 @@ test('It renders a link from a prosemirror doc using an alternate component when
   );
 });
 
+test('it does not warn about duplicate keys when a paragraph has multiple marked nodes', () => {
+  const consoleError = jest
+    .spyOn(console, 'error')
+    .mockImplementation(() => {});
+  const doc = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text: 'bold',
+            marks: [{ type: 'strong' }]
+          },
+          {
+            type: 'text',
+            text: ' and ',
+            marks: []
+          },
+          {
+            type: 'text',
+            text: 'italic',
+            marks: [{ type: 'em' }]
+          }
+        ]
+      }
+    ]
+  };
+  const { container } = render(<Body nodeData={doc} />);
+
+  expect(container.innerHTML).toEqual(
+    '<p><strong>bold</strong> and <em>italic</em></p>'
+  );
+  const duplicateKeyWarning = consoleError.mock.calls.some((call) =>
+    call.some((arg) => typeof arg === 'string' && arg.includes('same key'))
+  );
+  expect(duplicateKeyWarning).toBe(false);
+
+  consoleError.mockRestore();
+});
+
 test('it renders a nil doc', () => {
   const doc = null;
   const { container } = render(<Body nodeData={doc} />);

--- a/src/utils/Traverse.js
+++ b/src/utils/Traverse.js
@@ -33,9 +33,9 @@ const Traverse = (props) => {
     let InnerComponent = Inner(item, props, index);
 
     if (item.marks) {
-      item.marks.forEach((mark, markIndex) => {
+      item.marks.forEach((mark) => {
         const attrs = mark.attrs || {};
-        InnerComponent = Mark(mark, InnerComponent, attrs, props, markIndex);
+        InnerComponent = Mark(mark, InnerComponent, attrs, props, index);
       });
     }
 


### PR DESCRIPTION
Traverse() rebuilt each marked node's key from the mark's own index (markIndex, which restarts at 0 for every node) instead of the node's position in the content array. Since generateKey() returns `node-${index}` for any numeric index regardless of node type, every text node with exactly one mark (bold, italic, link, etc.) collapsed to the same key, node-0, causing "Encountered two children with the same key" whenever a paragraph had more than one such node.

Introduced in 29ba2bb ("generate a consistent key so we don't get a different key on server and client side renders"), which replaced the old uuid()-based keys (always unique, but mismatched between SSR and CSR) with the new index-based scheme.

Pass the node's index instead of markIndex when building the key for marked nodes, matching how Inner() already keys unmarked nodes.